### PR TITLE
Fix: Configure multiplayer for deployment

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,0 +1,24 @@
+# Environment variables for the Next.js Frontend (e.g., for Netlify)
+# Rename this file to .env.local for local development or set these in your hosting provider settings
+
+# URL of your deployed Socket.IO server
+# For local development, this would typically be: http://localhost:3001
+# For production, use the actual URL of your deployed server, e.g., wss://your-socket-server.example.com
+NEXT_PUBLIC_SOCKET_SERVER_URL=http://localhost:3001
+
+# ------------------------------------------------------------------------------------
+
+# Environment variables for the Socket.IO server (src/server/socket.ts)
+# These would be set on the platform where you deploy the socket.ts server (e.g., Render, Fly.io, Heroku)
+
+# Port for the Socket.IO server to listen on.
+# The platform might set this automatically. Defaults to 3001 if not set.
+# SOCKET_PORT=3001
+
+# Allowed origin for CORS - your deployed Netlify application URL
+# Example: https://your-app-name.netlify.app
+CORS_ORIGIN_PRODUCTION=
+
+# Allowed origin for CORS - your local development frontend URL
+# Example: http://localhost:3000 (if your Next.js dev server runs on port 3000)
+CORS_ORIGIN_DEVELOPMENT=http://localhost:3000

--- a/src/app/multiplayer/page.tsx
+++ b/src/app/multiplayer/page.tsx
@@ -6,6 +6,9 @@ import { Input } from "@/components/ui/input";
 import { useEffect, useState, useRef } from "react";
 import { io, Socket } from "socket.io-client";
 
+// Define the Socket.IO server URL using an environment variable or a default value
+const socketServerUrl = process.env.NEXT_PUBLIC_SOCKET_SERVER_URL || 'http://localhost:3001';
+
 // --- Interfaces (matching server-side structures) ---
 interface PlayerFromServer {
   id: string;
@@ -74,7 +77,7 @@ export default function MultiplayerPage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   useEffect(() => {
-    const newSocket = io('http://localhost:3001');
+    const newSocket = io(socketServerUrl);
     setSocket(newSocket);
 
     newSocket.on('connect', () => {

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -54,9 +54,25 @@ const lobbies: Record<string, Lobby> = {};
 const MAX_PLAYERS_PER_LOBBY = 2;
 
 const httpServer: HTTPServer = createServer();
+
+// Define allowed origins for CORS
+const allowedOrigins: string[] = [];
+if (process.env.CORS_ORIGIN_PRODUCTION) {
+  allowedOrigins.push(process.env.CORS_ORIGIN_PRODUCTION);
+}
+if (process.env.CORS_ORIGIN_DEVELOPMENT) {
+  allowedOrigins.push(process.env.CORS_ORIGIN_DEVELOPMENT);
+}
+
+// If no environment variables are set, use default development origins
+if (allowedOrigins.length === 0) {
+  allowedOrigins.push('http://localhost:3000');
+  allowedOrigins.push('http://localhost:9002'); // Default for current setup
+}
+
 const io = new SocketIOServer(httpServer, {
   cors: {
-    origin: "http://localhost:9002", // Assuming Next.js runs on 9002
+    origin: allowedOrigins.length === 1 ? allowedOrigins[0] : allowedOrigins,
     methods: ["GET", "POST"],
     credentials: true // Often needed
   }


### PR DESCRIPTION
This commit addresses the "Connection Failed: xhr poll error" issue in multiplayer mode when deployed.

Changes:
- I parameterized the client-side Socket.IO server URL in `src/app/multiplayer/page.tsx` using the `NEXT_PUBLIC_SOCKET_SERVER_URL` environment variable. This allows the client to connect to the correct server URL in different environments (local, production). A fallback to `http://localhost:3001` is included for ease of local development.
- I made the server-side CORS configuration in `src/server/socket.ts` dynamic. It now accepts origins from `CORS_ORIGIN_PRODUCTION` and `CORS_ORIGIN_DEVELOPMENT` environment variables, with fallbacks to common local development URLs (`http://localhost:3000`, `http://localhost:9002`). This ensures the Socket.IO server allows connections from the deployed Netlify frontend and local development environments.
- I added an `env.example` file to provide a template for the required environment variables for both the Next.js frontend and the Socket.IO backend.

These changes require you to:
1. Deploy the `src/server/socket.ts` (Socket.IO server) to a suitable hosting platform (e.g., Render, Fly.io, Heroku).
2. Configure the necessary environment variables on both the Netlify platform (for the Next.js app) and the Socket.IO server hosting platform.